### PR TITLE
Scc 2888

### DIFF
--- a/lib/discovery-store-model.js
+++ b/lib/discovery-store-model.js
@@ -180,6 +180,10 @@ const filterOutNonResearchBibs = (bibs) => {
       // If bib has locations and all locations are classified as Branch,
       // remove bib:
       if (bib.locations && Array.isArray(bib.locations) && bib.locations.length > 0) {
+        // If bib has 'os' or 'none' location it may be OTF, so pass it through
+        // and let discovery-api-indexer handle suppressing it if needed
+        if (bib.locations[0] && ['none', 'os'].includes(bib.locations[0].code)) return Promise.resolve(bib)
+
         const researchLocations = bib.locations
           .map((location) => nyplCoreLocations[location.code] || {})
           .filter((location) => (location.collectionTypes || []).includes('Research'))

--- a/test/discovery-store-models-test.js
+++ b/test/discovery-store-models-test.js
@@ -143,5 +143,28 @@ describe('discovery-store-model', () => {
         expect(filtered).to.have.lengthOf(1)
       })
     })
+
+    it('assumes bibs with location code "none" or "os" are Research (to ensure they are suppressed)', () => {
+      return discoveryStoreModel.filterOutNonResearchBibs([
+        {
+          nyplSource: 'sierra-nypl',
+          id: 'research-bib-1',
+          locations: [
+            { code: 'none', name: 'This is a location that appears sometimes for 0-item bibs' }
+          ]
+        },
+        {
+          nyplSource: 'sierra-nypl',
+          id: 'research-bibjj-2',
+          locations: [
+            { code: 'os', name: 'This is the OTF location, which nypl-core-objects considers Branch' }
+          ]
+        }
+
+      ]).then((filtered) => {
+        expect(filtered).to.be.a('array')
+        expect(filtered).to.have.lengthOf(2)
+      })
+    })
   })
 })


### PR DESCRIPTION
This addresses a bug in the DiscoveryHybridIndexer ("Indexer") where OTF records can sneak into the index in some cases. One scenario:

 - OTF record created (comprising a single bib and single item record created through the Sierra API)
 - Bib record gets polled and sent down the Bib stream, where it's picked up by the Indexer
 - The Indexer sees that it has an empty `locations` array, so has no reason to skip processing it as Branch
 - It proceeds to index the OFT bib without items
 - Some time thereafter if the Item record arrives, the Indexer skips processing the item (because location 'os' is a Branch location)
 - If another update comes through on the Bib (e.g. Sierra has now added the 'os' item location to its `locations` property), the Bib was still considered Branch (because location 'os' is a Branch location)

This essentially just patches the criteria for skipping Branch bibs to override the default assumption and consider Bibs with location 'os' or 'none' as Research so that they are not *skipped*. (If they're not skipped, they'll be fully processed, which will allow them to be suppressed.)

Long term we need a way to unambiguously identify OTF Bibs as such. I've noted that here https://jira.nypl.org/browse/SCC-2906

https://jira.nypl.org/browse/SCC-2888