### PR TITLE
Hotfix problem parsing empty oclc

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "discovery-api-indexer": "git+https://github.com/NYPL-discovery/discovery-api-indexer.git",
     "discovery-store-models": "git+https://github.com/NYPL-discovery/discovery-store-models.git#v1.4.0",
     "highland": "^2.13.5",
-    "pcdm-store-updater": "git+https://github.com/NYPL-discovery/discovery-store-poster.git#v1.1.0",
+    "pcdm-store-updater": "git+https://github.com/NYPL-discovery/discovery-store-poster.git#v1.1.1",
     "pg-query-stream": "^4.1.0",
     "proxyquire": "^2.1.3",
     "winston": "^2.4.4"


### PR DESCRIPTION
This just bumps the version of discovery-store-poster to v1.1.1, which includes a fix for how oclc numbers are parsed. I recently found this issue was causing errors in production, so had to hotfix it out to qa and prod. This PR just ensures that hotfix is also applied to `development`