### PR TITLE
Bump discoverys-store-poster to 1.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "discovery-api-indexer": "git+https://github.com/NYPL-discovery/discovery-api-indexer.git",
     "discovery-store-models": "git+https://github.com/NYPL-discovery/discovery-store-models.git#v1.4.0",
     "highland": "^2.13.5",
-    "pcdm-store-updater": "git+https://github.com/NYPL-discovery/discovery-store-poster.git#v1.1.1",
+    "pcdm-store-updater": "git+https://github.com/NYPL-discovery/discovery-store-poster.git#v1.1.2",
     "pg-query-stream": "^4.1.0",
     "proxyquire": "^2.1.3",
     "winston": "^2.4.4"


### PR DESCRIPTION
Bump discovery-store-poster to v1.1.2 to incorporate changes for https://jira.nypl.org/browse/SCC-2910