### PR TITLE
Set store-poster to 1.1.6 to reenable scsb queries

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,10 +13,10 @@
         "@nypl/nypl-data-api-client": "^1.0.4",
         "avsc": "^5.7.1",
         "deep-object-diff": "^1.1.0",
-        "discovery-api-indexer": "git+https://github.com/NYPL-discovery/discovery-api-indexer.git#v1.0.0",
+        "discovery-api-indexer": "git+https://github.com/NYPL-discovery/discovery-api-indexer.git#v1.0.1",
         "discovery-store-models": "git+https://github.com/NYPL-discovery/discovery-store-models.git#v1.4.0",
         "highland": "^2.13.5",
-        "pcdm-store-updater": "git+https://github.com/NYPL-discovery/discovery-store-poster#v1.1.4",
+        "pcdm-store-updater": "git+https://github.com/NYPL-discovery/discovery-store-poster#v1.1.6",
         "pg-query-stream": "^4.1.0",
         "proxyquire": "^2.1.3",
         "winston": "^2.4.4"
@@ -7254,7 +7254,7 @@
     },
     "discovery-api-indexer": {
       "version": "git+ssh://git@github.com/NYPL-discovery/discovery-api-indexer.git#ea8639fda5fe5fd792d14547d48a87ac75d95f75",
-      "from": "discovery-api-indexer@git+https://github.com/NYPL-discovery/discovery-api-indexer.git#v1.0.0",
+      "from": "discovery-api-indexer@git+https://github.com/NYPL-discovery/discovery-api-indexer.git#v1.0.1",
       "requires": {
         "@nypl/nypl-core-objects": "^2.0.0",
         "@nypl/nypl-data-api-client": "^1.0.4",
@@ -9546,7 +9546,7 @@
     },
     "pcdm-store-updater": {
       "version": "git+ssh://git@github.com/NYPL-discovery/discovery-store-poster.git#c5a41fcd619504a7136a7f3492bbbc9b6d845688",
-      "from": "pcdm-store-updater@git+https://github.com/NYPL-discovery/discovery-store-poster#v1.1.4",
+      "from": "pcdm-store-updater@git+https://github.com/NYPL-discovery/discovery-store-poster#v1.1.6",
       "requires": {
         "@nypl/nypl-core-objects": "^2.0.0",
         "@nypl/nypl-data-api-client": "^0.2.5",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "discovery-api-indexer": "git+https://github.com/NYPL-discovery/discovery-api-indexer.git#v1.0.1",
     "discovery-store-models": "git+https://github.com/NYPL-discovery/discovery-store-models.git#v1.4.0",
     "highland": "^2.13.5",
-    "pcdm-store-updater": "git+https://github.com/NYPL-discovery/discovery-store-poster#v1.1.4",
+    "pcdm-store-updater": "git+https://github.com/NYPL-discovery/discovery-store-poster#v1.1.6",
     "pg-query-stream": "^4.1.0",
     "proxyquire": "^2.1.3",
     "winston": "^2.4.4"


### PR DESCRIPTION
We had previously disabled querying scsb for recap customer codes due to it sending invalid queries when items lacked a barcode. This reenables SCSB api querying with a better barcode check.