### PR TITLE
Fix: Remove trailing punctuation from values

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "discovery-api-indexer": "git+https://github.com/NYPL-discovery/discovery-api-indexer.git#v1.0.2",
         "discovery-store-models": "github:NYPL-discovery/discovery-store-models#v1.4.2",
         "highland": "^2.13.5",
-        "pcdm-store-updater": "github:NYPL-discovery/discovery-store-poster#v1.2.3",
+        "pcdm-store-updater": "github:NYPL-discovery/discovery-store-poster#v1.2.4",
         "pg-query-stream": "^4.1.0",
         "proxyquire": "^2.1.3",
         "winston": "^2.4.4"
@@ -1233,6 +1233,33 @@
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
       "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c="
     },
+    "node_modules/discovery-api-indexer/node_modules/discovery-store-models": {
+      "version": "1.4.1",
+      "resolved": "git+ssh://git@github.com/NYPL-discovery/discovery-store-models.git#a92ad4f0a11f24850bbd24dce18c1f53026c50a2",
+      "integrity": "sha512-aGwzRlJlEOFr5qqI9dAz5K/JodI+r1DWR5jga6ZZNddQYDYLcmo3azEIrdkNTRwPPtVT4+GETtPsacn5eaQrDA==",
+      "license": "ISC",
+      "dependencies": {
+        "@nypl/nypl-core-objects": "^2.0.0",
+        "pg-promise": "^7.4.0",
+        "winston": "^2.4.0"
+      }
+    },
+    "node_modules/discovery-api-indexer/node_modules/discovery-store-models/node_modules/pg-promise": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/pg-promise/-/pg-promise-7.5.4.tgz",
+      "integrity": "sha512-wuL+13P+Ris8MEUpdatv7OH5eHEahWBNmgGHEwLd88fym/eMAjxrFV+3jRKO7bFAyDTvo3wNcmuntYwR9eJnvg==",
+      "deprecated": "This version of pg-promise is obsolete. You should update to a newer version.",
+      "dependencies": {
+        "manakin": "~0.5.1",
+        "pg": "~7.4.1",
+        "pg-minify": "~0.5.4",
+        "spex": "~2.0.2"
+      },
+      "engines": {
+        "node": ">=4.5",
+        "npm": ">=2.15"
+      }
+    },
     "node_modules/discovery-api-indexer/node_modules/dotenv": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-4.0.0.tgz",
@@ -1300,6 +1327,7 @@
     "node_modules/discovery-store-models": {
       "version": "1.4.2",
       "resolved": "git+ssh://git@github.com/NYPL-discovery/discovery-store-models.git#187b2755ce94689386f882da25181a2d9446b9e7",
+      "integrity": "sha512-o3qY8VMd7Bga0o+/1Lt8MPqts09Mx6ngw7FBBnhuRn3vyGID+6WU+caCoTWqn3HAWOkPRBmWngOhg9fz8eGYOQ==",
       "license": "ISC",
       "dependencies": {
         "@nypl/nypl-core-objects": "^2.0.0",
@@ -3604,15 +3632,20 @@
       }
     },
     "node_modules/mkdirp": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "dependencies": {
-        "minimist": "^1.2.5"
+        "minimist": "^1.2.6"
       },
       "bin": {
         "mkdirp": "bin/cmd.js"
       }
+    },
+    "node_modules/mkdirp/node_modules/minimist": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
     "node_modules/mocha": {
       "version": "9.2.1",
@@ -4180,8 +4213,9 @@
       }
     },
     "node_modules/pcdm-store-updater": {
-      "version": "1.2.3",
-      "resolved": "git+ssh://git@github.com/NYPL-discovery/discovery-store-poster.git#1c5975eebf11be77926900d95335999ff2a19c43",
+      "version": "1.2.4",
+      "resolved": "git+ssh://git@github.com/NYPL-discovery/discovery-store-poster.git#be6a9ba6fd6f20a53c0196fa50552bcdacb3cc56",
+      "integrity": "sha512-hxR4FxcE9LANWmSKQYkh9c1eVi12pB0TeRxpVlE5I7cQYW9a01SiWNxwZFy7cts8sCYRvXSg6I8F/sn2aaiviA==",
       "license": "MIT",
       "dependencies": {
         "@nypl/nypl-core-objects": "^2.0.0",
@@ -4223,9 +4257,9 @@
       }
     },
     "node_modules/pcdm-store-updater/node_modules/@nypl/nypl-data-api-client/node_modules/avsc": {
-      "version": "5.7.3",
-      "resolved": "https://registry.npmjs.org/avsc/-/avsc-5.7.3.tgz",
-      "integrity": "sha512-uUbetCWczQHbsKyX1C99XpQHBM8SWfovvaZhPIj23/1uV7SQf0WeRZbiLpw0JZm+LHTChfNgrLfDJOVoU2kU+A==",
+      "version": "5.7.4",
+      "resolved": "https://registry.npmjs.org/avsc/-/avsc-5.7.4.tgz",
+      "integrity": "sha512-z4oo33lmnvvNRqfUe3YjDGGpqu/L2+wXBIhMtwq6oqZ+exOUAkQYM6zd2VWKF7AIlajOF8ZZuPFfryTG9iLC/w==",
       "engines": {
         "node": ">=0.11"
       }
@@ -4238,6 +4272,17 @@
         "node": ">=0.11"
       }
     },
+    "node_modules/pcdm-store-updater/node_modules/discovery-store-models": {
+      "version": "1.4.0",
+      "resolved": "git+ssh://git@github.com/NYPL-discovery/discovery-store-models.git#db629bc89dd8d8c26cc8e1e1aa11a515fb9f35a6",
+      "integrity": "sha512-QqvhjVbpSXeGrMxKrR0+OKR0jDUOYd9ZZaPtEfaMndmIW49Ts6HQi7IdYbF/UGNBaKbIswqqlUKPLpc8LzdGQw==",
+      "license": "ISC",
+      "dependencies": {
+        "@nypl/nypl-core-objects": "^2.0.0",
+        "pg-promise": "^7.4.0",
+        "winston": "^2.4.0"
+      }
+    },
     "node_modules/pcdm-store-updater/node_modules/dotenv": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-4.0.0.tgz",
@@ -4246,12 +4291,7 @@
         "node": ">=4.6.0"
       }
     },
-    "node_modules/performance-now": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
-    },
-    "node_modules/pg": {
+    "node_modules/pcdm-store-updater/node_modules/pg": {
       "version": "6.4.2",
       "resolved": "https://registry.npmjs.org/pg/-/pg-6.4.2.tgz",
       "integrity": "sha1-w2QBEGDqx6UHoq4GPrhX7OkQ4n8=",
@@ -4267,6 +4307,89 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/pcdm-store-updater/node_modules/pg-pool": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-2.0.10.tgz",
+      "integrity": "sha512-qdwzY92bHf3nwzIUcj+zJ0Qo5lpG/YxchahxIN8+ZVmXqkahKXsnl2aiJPHLYN9o5mB/leG+Xh6XKxtP7e0sjg==",
+      "peerDependencies": {
+        "pg": ">5.0"
+      }
+    },
+    "node_modules/pcdm-store-updater/node_modules/pg-promise": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/pg-promise/-/pg-promise-7.5.4.tgz",
+      "integrity": "sha512-wuL+13P+Ris8MEUpdatv7OH5eHEahWBNmgGHEwLd88fym/eMAjxrFV+3jRKO7bFAyDTvo3wNcmuntYwR9eJnvg==",
+      "deprecated": "This version of pg-promise is obsolete. You should update to a newer version.",
+      "dependencies": {
+        "manakin": "~0.5.1",
+        "pg": "~7.4.1",
+        "pg-minify": "~0.5.4",
+        "spex": "~2.0.2"
+      },
+      "engines": {
+        "node": ">=4.5",
+        "npm": ">=2.15"
+      }
+    },
+    "node_modules/pcdm-store-updater/node_modules/pg-promise/node_modules/pg": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-7.4.3.tgz",
+      "integrity": "sha1-97b5P1NA7MJZavu5ShPj1rYJg0s=",
+      "dependencies": {
+        "buffer-writer": "1.0.1",
+        "packet-reader": "0.3.1",
+        "pg-connection-string": "0.1.3",
+        "pg-pool": "~2.0.3",
+        "pg-types": "~1.12.1",
+        "pgpass": "1.x",
+        "semver": "4.3.2"
+      },
+      "engines": {
+        "node": ">= 4.5.0"
+      }
+    },
+    "node_modules/pcdm-store-updater/node_modules/pg-types": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-1.12.1.tgz",
+      "integrity": "sha1-1kCH45A7WP+q0nnnWVxSIIoUw9I=",
+      "dependencies": {
+        "postgres-array": "~1.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.0",
+        "postgres-interval": "^1.1.0"
+      }
+    },
+    "node_modules/pcdm-store-updater/node_modules/pg/node_modules/pg-pool": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-1.8.0.tgz",
+      "integrity": "sha1-9+xzgkw3oD8Hb1G/33DjQBR8Tzc=",
+      "dependencies": {
+        "generic-pool": "2.4.3",
+        "object-assign": "4.1.0"
+      }
+    },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+    },
+    "node_modules/pg": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-7.4.3.tgz",
+      "integrity": "sha1-97b5P1NA7MJZavu5ShPj1rYJg0s=",
+      "dependencies": {
+        "buffer-writer": "1.0.1",
+        "packet-reader": "0.3.1",
+        "pg-connection-string": "0.1.3",
+        "pg-pool": "~2.0.3",
+        "pg-types": "~1.12.1",
+        "pgpass": "1.x",
+        "semver": "4.3.2"
+      },
+      "engines": {
+        "node": ">= 4.5.0"
       }
     },
     "node_modules/pg-connection-string": {
@@ -4482,6 +4605,25 @@
       "integrity": "sha512-lfKli0Gkl/+za/+b6lzENajczwZHc7D5kiUCZfgm914jipD2kIOIvEkAhZ8GrW3/TUoP9w8FHjwpPObBye5KQQ==",
       "dependencies": {
         "pg-int8": "1.0.1",
+        "postgres-array": "~1.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.0",
+        "postgres-interval": "^1.1.0"
+      }
+    },
+    "node_modules/pg/node_modules/pg-pool": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-2.0.10.tgz",
+      "integrity": "sha512-qdwzY92bHf3nwzIUcj+zJ0Qo5lpG/YxchahxIN8+ZVmXqkahKXsnl2aiJPHLYN9o5mB/leG+Xh6XKxtP7e0sjg==",
+      "peerDependencies": {
+        "pg": ">5.0"
+      }
+    },
+    "node_modules/pg/node_modules/pg-types": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-1.12.1.tgz",
+      "integrity": "sha1-1kCH45A7WP+q0nnnWVxSIIoUw9I=",
+      "dependencies": {
         "postgres-array": "~1.0.0",
         "postgres-bytea": "~1.0.0",
         "postgres-date": "~1.0.0",
@@ -7249,7 +7391,6 @@
     },
     "discovery-api-indexer": {
       "version": "git+ssh://git@github.com/NYPL-discovery/discovery-api-indexer.git#fef1a08372967940625b33b1e41bec58e208612f",
-      "integrity": "sha512-GDbF3Xa/k6wISvT4rcqQHjb/w1Ty4OtyuKi2olKslTxapLx+XW6w3yeXlXHFq4pIKYTDVJPspEdDvW5zMYeQsQ==",
       "from": "discovery-api-indexer@git+https://github.com/NYPL-discovery/discovery-api-indexer.git#v1.0.2",
       "requires": {
         "@nypl/nypl-core-objects": "^2.0.0",
@@ -7278,6 +7419,28 @@
           "version": "0.11.0",
           "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
           "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c="
+        },
+        "discovery-store-models": {
+          "version": "git+ssh://git@github.com/NYPL-discovery/discovery-store-models.git#a92ad4f0a11f24850bbd24dce18c1f53026c50a2",
+          "from": "discovery-store-models@git+https://github.com/NYPL-discovery/discovery-store-models.git#v1.4.1",
+          "requires": {
+            "@nypl/nypl-core-objects": "^2.0.0",
+            "pg-promise": "^7.4.0",
+            "winston": "^2.4.0"
+          },
+          "dependencies": {
+            "pg-promise": {
+              "version": "7.5.4",
+              "resolved": "https://registry.npmjs.org/pg-promise/-/pg-promise-7.5.4.tgz",
+              "integrity": "sha512-wuL+13P+Ris8MEUpdatv7OH5eHEahWBNmgGHEwLd88fym/eMAjxrFV+3jRKO7bFAyDTvo3wNcmuntYwR9eJnvg==",
+              "requires": {
+                "manakin": "~0.5.1",
+                "pg": "~7.4.1",
+                "pg-minify": "~0.5.4",
+                "spex": "~2.0.2"
+              }
+            }
+          }
         },
         "dotenv": {
           "version": "4.0.0",
@@ -9070,11 +9233,18 @@
       "integrity": "sha512-3KYa4m4Vlqx98GPdOHghxSdNtTvcP8E0kkaJ5Dlh+h2DRzF7zpuVVcA8B0QpKd11YJeP9QQ7ASkKzOeu195Wzw=="
     },
     "mkdirp": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "requires": {
-        "minimist": "^1.2.5"
+        "minimist": "^1.2.6"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.6",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+          "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
+        }
       }
     },
     "mocha": {
@@ -9526,8 +9696,8 @@
       "dev": true
     },
     "pcdm-store-updater": {
-      "version": "git+ssh://git@github.com/NYPL-discovery/discovery-store-poster.git#1c5975eebf11be77926900d95335999ff2a19c43",
-      "from": "pcdm-store-updater@github:NYPL-discovery/discovery-store-poster#v1.2.3",
+      "version": "git+ssh://git@github.com/NYPL-discovery/discovery-store-poster.git#be6a9ba6fd6f20a53c0196fa50552bcdacb3cc56",
+      "from": "pcdm-store-updater@github:NYPL-discovery/discovery-store-poster#v1.2.4",
       "requires": {
         "@nypl/nypl-core-objects": "^2.0.0",
         "@nypl/nypl-data-api-client": "^0.2.5",
@@ -9565,9 +9735,9 @@
           },
           "dependencies": {
             "avsc": {
-              "version": "5.7.3",
-              "resolved": "https://registry.npmjs.org/avsc/-/avsc-5.7.3.tgz",
-              "integrity": "sha512-uUbetCWczQHbsKyX1C99XpQHBM8SWfovvaZhPIj23/1uV7SQf0WeRZbiLpw0JZm+LHTChfNgrLfDJOVoU2kU+A=="
+              "version": "5.7.4",
+              "resolved": "https://registry.npmjs.org/avsc/-/avsc-5.7.4.tgz",
+              "integrity": "sha512-z4oo33lmnvvNRqfUe3YjDGGpqu/L2+wXBIhMtwq6oqZ+exOUAkQYM6zd2VWKF7AIlajOF8ZZuPFfryTG9iLC/w=="
             }
           }
         },
@@ -9576,10 +9746,89 @@
           "resolved": "https://registry.npmjs.org/avsc/-/avsc-4.1.11.tgz",
           "integrity": "sha1-0lE1Kig7fsDilBMSfJnq/qObb3g="
         },
+        "discovery-store-models": {
+          "version": "git+ssh://git@github.com/NYPL-discovery/discovery-store-models.git#db629bc89dd8d8c26cc8e1e1aa11a515fb9f35a6",
+          "from": "discovery-store-models@git+https://github.com/NYPL-discovery/discovery-store-models.git#v1.4.0",
+          "requires": {
+            "@nypl/nypl-core-objects": "^2.0.0",
+            "pg-promise": "^7.4.0",
+            "winston": "^2.4.0"
+          }
+        },
         "dotenv": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-4.0.0.tgz",
           "integrity": "sha1-hk7xN5rO1Vzm+V3r7NzhefegzR0="
+        },
+        "pg": {
+          "version": "6.4.2",
+          "resolved": "https://registry.npmjs.org/pg/-/pg-6.4.2.tgz",
+          "integrity": "sha1-w2QBEGDqx6UHoq4GPrhX7OkQ4n8=",
+          "requires": {
+            "buffer-writer": "1.0.1",
+            "js-string-escape": "1.0.1",
+            "packet-reader": "0.3.1",
+            "pg-connection-string": "0.1.3",
+            "pg-pool": "1.*",
+            "pg-types": "1.*",
+            "pgpass": "1.*",
+            "semver": "4.3.2"
+          },
+          "dependencies": {
+            "pg-pool": {
+              "version": "1.8.0",
+              "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-1.8.0.tgz",
+              "integrity": "sha1-9+xzgkw3oD8Hb1G/33DjQBR8Tzc=",
+              "requires": {
+                "generic-pool": "2.4.3",
+                "object-assign": "4.1.0"
+              }
+            }
+          }
+        },
+        "pg-pool": {
+          "version": "2.0.10",
+          "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-2.0.10.tgz",
+          "integrity": "sha512-qdwzY92bHf3nwzIUcj+zJ0Qo5lpG/YxchahxIN8+ZVmXqkahKXsnl2aiJPHLYN9o5mB/leG+Xh6XKxtP7e0sjg==",
+          "requires": {}
+        },
+        "pg-promise": {
+          "version": "7.5.4",
+          "resolved": "https://registry.npmjs.org/pg-promise/-/pg-promise-7.5.4.tgz",
+          "integrity": "sha512-wuL+13P+Ris8MEUpdatv7OH5eHEahWBNmgGHEwLd88fym/eMAjxrFV+3jRKO7bFAyDTvo3wNcmuntYwR9eJnvg==",
+          "requires": {
+            "manakin": "~0.5.1",
+            "pg": "~7.4.1",
+            "pg-minify": "~0.5.4",
+            "spex": "~2.0.2"
+          },
+          "dependencies": {
+            "pg": {
+              "version": "7.4.3",
+              "resolved": "https://registry.npmjs.org/pg/-/pg-7.4.3.tgz",
+              "integrity": "sha1-97b5P1NA7MJZavu5ShPj1rYJg0s=",
+              "requires": {
+                "buffer-writer": "1.0.1",
+                "packet-reader": "0.3.1",
+                "pg-connection-string": "0.1.3",
+                "pg-pool": "~2.0.3",
+                "pg-types": "~1.12.1",
+                "pgpass": "1.x",
+                "semver": "4.3.2"
+              }
+            }
+          }
+        },
+        "pg-types": {
+          "version": "1.12.1",
+          "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-1.12.1.tgz",
+          "integrity": "sha1-1kCH45A7WP+q0nnnWVxSIIoUw9I=",
+          "requires": {
+            "postgres-array": "~1.0.0",
+            "postgres-bytea": "~1.0.0",
+            "postgres-date": "~1.0.0",
+            "postgres-interval": "^1.1.0"
+          }
         }
       }
     },
@@ -9589,18 +9838,36 @@
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "pg": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/pg/-/pg-6.4.2.tgz",
-      "integrity": "sha1-w2QBEGDqx6UHoq4GPrhX7OkQ4n8=",
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-7.4.3.tgz",
+      "integrity": "sha1-97b5P1NA7MJZavu5ShPj1rYJg0s=",
       "requires": {
         "buffer-writer": "1.0.1",
-        "js-string-escape": "1.0.1",
         "packet-reader": "0.3.1",
         "pg-connection-string": "0.1.3",
-        "pg-pool": "1.*",
-        "pg-types": "1.*",
-        "pgpass": "1.*",
+        "pg-pool": "~2.0.3",
+        "pg-types": "~1.12.1",
+        "pgpass": "1.x",
         "semver": "4.3.2"
+      },
+      "dependencies": {
+        "pg-pool": {
+          "version": "2.0.10",
+          "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-2.0.10.tgz",
+          "integrity": "sha512-qdwzY92bHf3nwzIUcj+zJ0Qo5lpG/YxchahxIN8+ZVmXqkahKXsnl2aiJPHLYN9o5mB/leG+Xh6XKxtP7e0sjg==",
+          "requires": {}
+        },
+        "pg-types": {
+          "version": "1.12.1",
+          "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-1.12.1.tgz",
+          "integrity": "sha1-1kCH45A7WP+q0nnnWVxSIIoUw9I=",
+          "requires": {
+            "postgres-array": "~1.0.0",
+            "postgres-bytea": "~1.0.0",
+            "postgres-date": "~1.0.0",
+            "postgres-interval": "^1.1.0"
+          }
+        }
       }
     },
     "pg-connection-string": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "discovery-api-indexer": "git+https://github.com/NYPL-discovery/discovery-api-indexer.git#v1.0.2",
     "discovery-store-models": "github:NYPL-discovery/discovery-store-models#v1.4.2",
     "highland": "^2.13.5",
-    "pcdm-store-updater": "github:NYPL-discovery/discovery-store-poster#v1.2.3",
+    "pcdm-store-updater": "github:NYPL-discovery/discovery-store-poster#v1.2.4",
     "pg-query-stream": "^4.1.0",
     "proxyquire": "^2.1.3",
     "winston": "^2.4.4"

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -77,7 +77,7 @@ describe('index.handler', () => {
             ])
             expect(indexedDocuments[0].issuance_packed).to.eql(['urn:biblevel:m||monograph/item'])
             expect(indexedDocuments[0].language_packed).to.eql(['lang:arm||Armenian'])
-            expect(indexedDocuments[0].title).to.eql(['Niwtʻer azgayin patmutʻian hamar Ereveli hay kazunkʻ ; Parskastan /'])
+            expect(indexedDocuments[0].title).to.eql(['Niwtʻer azgayin patmutʻian hamar Ereveli hay kazunkʻ ; Parskastan'])
             expect(indexedDocuments[0].subjectLiteral_exploded).to.include.members([
               'Armenians',
               'Armenians -- Iran',


### PR DESCRIPTION
Incorporates latest discovery-store-poster version to:
 - Remove trailing slash, comma, and colon from certain
   extracted literal literal values.