### PR TITLE
Fix issues with customer code lookup

### DIFF
--- a/lib/attach-recap-to-items.js
+++ b/lib/attach-recap-to-items.js
@@ -24,7 +24,7 @@ const _createRecapCodeMap = async (bib) => {
     const scsbFriendlyBibId = '.b' + bNumberWithCheckDigit(bib.id)
     const updatedRecapBib = await client.search({ deleted: false, fieldValue: scsbFriendlyBibId, fieldName: 'OwningInstitutionBibId', owningInstitutions: ['NYPL'] })
     const elapsed = ((new Date()) - __start)
-    logger.debug({ message: `HTC searchByParam API took ${elapsed}ms`, metric: 'searchByParam-owningInstitutionBibId', timeMs: elapsed })
+    logger.debug(`HTC searchByParam API took ${elapsed}ms`, { metric: 'searchByParam-owningInstitutionBibId', timeMs: elapsed })
     if (updatedRecapBib && updatedRecapBib.searchResultRows && updatedRecapBib.searchResultRows.length) {
       const results = updatedRecapBib.searchResultRows
       if (results && (results.length > 0) && results[0].searchItemResultRows && results[0].searchItemResultRows.length > 0) {

--- a/lib/discovery-store-model.js
+++ b/lib/discovery-store-model.js
@@ -14,7 +14,7 @@ const SierraHolding = require('pcdm-store-updater/lib/models/holding-sierra-reco
 
 const platformApi = require('./platform-api')
 const logger = require('./logger')
-const attachRecapCustomerCodes = require('./attach-recap-to-items')
+const { attachRecapCustomerCodes } = require('./attach-recap-to-items')
 
 function groupStatementsBySubjectId (statements) {
   return Object.values(
@@ -79,7 +79,7 @@ const discoveryStoreModelFromStatements = (statements, ModelKlass) => {
 }
 
 const discoveryStoreBib = (bib) => {
-  logger.debug('Extracting bib statements from ', bib)
+  logger.debug('Extracting bib statements from ', bib.id)
   return (new BibsUpdater()).extractStatements(new SierraBib(bib))
     .then((bibStatements) => {
       // Identify electronic item statements extracted from bib record:

--- a/package-lock.json
+++ b/package-lock.json
@@ -4185,15 +4185,13 @@
       }
     },
     "node_modules/pcdm-store-updater": {
-      "version": "1.2.4",
-      "resolved": "git+ssh://git@github.com/NYPL-discovery/discovery-store-poster.git#be6a9ba6fd6f20a53c0196fa50552bcdacb3cc56",
-      "integrity": "sha512-hxR4FxcE9LANWmSKQYkh9c1eVi12pB0TeRxpVlE5I7cQYW9a01SiWNxwZFy7cts8sCYRvXSg6I8F/sn2aaiviA==",
+      "version": "1.3.0",
+      "resolved": "git+ssh://git@github.com/NYPL-discovery/discovery-store-poster.git#633a365114846455a78f1af1347dc73418e1b25a",
       "license": "MIT",
       "dependencies": {
         "@nypl/nypl-core-objects": "^2.0.0",
         "@nypl/nypl-data-api-client": "^0.2.5",
         "@nypl/nypl-streams-client": "^0.1.4",
-        "@nypl/scsb-rest-client": "^1.0.6",
         "avsc": "^4.1.9",
         "aws-sdk": "^2.96.0",
         "bluebird": "^3.7.2",
@@ -4268,17 +4266,6 @@
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/pcdm-store-updater/node_modules/pg-types": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-1.12.1.tgz",
-      "integrity": "sha1-1kCH45A7WP+q0nnnWVxSIIoUw9I=",
-      "dependencies": {
-        "postgres-array": "~1.0.0",
-        "postgres-bytea": "~1.0.0",
-        "postgres-date": "~1.0.0",
-        "postgres-interval": "^1.1.0"
       }
     },
     "node_modules/pcdm-store-updater/node_modules/pg/node_modules/pg-pool": {
@@ -9554,14 +9541,12 @@
       "dev": true
     },
     "pcdm-store-updater": {
-      "version": "git+ssh://git@github.com/NYPL-discovery/discovery-store-poster.git#be6a9ba6fd6f20a53c0196fa50552bcdacb3cc56",
-      "integrity": "sha512-hxR4FxcE9LANWmSKQYkh9c1eVi12pB0TeRxpVlE5I7cQYW9a01SiWNxwZFy7cts8sCYRvXSg6I8F/sn2aaiviA==",
+      "version": "git+ssh://git@github.com/NYPL-discovery/discovery-store-poster.git#633a365114846455a78f1af1347dc73418e1b25a",
       "from": "pcdm-store-updater@github:NYPL-discovery/discovery-store-poster#v1.3.0",
       "requires": {
         "@nypl/nypl-core-objects": "^2.0.0",
         "@nypl/nypl-data-api-client": "^0.2.5",
         "@nypl/nypl-streams-client": "^0.1.4",
-        "@nypl/scsb-rest-client": "^1.0.6",
         "avsc": "^4.1.9",
         "aws-sdk": "^2.96.0",
         "bluebird": "^3.7.2",
@@ -9634,17 +9619,6 @@
                 "object-assign": "4.1.0"
               }
             }
-          }
-        },
-        "pg-types": {
-          "version": "1.12.1",
-          "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-1.12.1.tgz",
-          "integrity": "sha1-1kCH45A7WP+q0nnnWVxSIIoUw9I=",
-          "requires": {
-            "postgres-array": "~1.0.0",
-            "postgres-bytea": "~1.0.0",
-            "postgres-date": "~1.0.0",
-            "postgres-interval": "^1.1.0"
           }
         }
       }

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -3,7 +3,7 @@ const discoveryApiIndex = require('discovery-api-indexer/lib/index')
 const NyplStreamsClient = require('@nypl/nypl-streams-client')
 // For stubbing scsb client instantiation from a different module
 const kmsHelperPcdm = require('pcdm-store-updater/lib/kms-helper')
-const ScsbClient = require('pcdm-store-updater/lib/scsb-client')
+const ScsbClient = require('../lib/scsb-client')
 
 const kmsHelper = require('../lib/kms-helper')
 const index = require('../index')


### PR DESCRIPTION
Fix a few issues with customer code lookup:
 - Ensure package-lock targets v1.3.0 of pcdm-store-updater (previously
 was locked on 1.2.4, I believe due to the version having not been
 updated in that module's package.json?)
 - When requiring attach-recap-to-items, destructure the functions so
 they can be called