### PR TITLE
SCC-3076: Update discovery-api-indexer to v1.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@nypl/scsb-rest-client": "^1.0.6",
         "avsc": "^5.7.1",
         "deep-object-diff": "^1.1.0",
-        "discovery-api-indexer": "git+https://github.com/NYPL-discovery/discovery-api-indexer.git#v1.0.3",
+        "discovery-api-indexer": "github:NYPL-discovery/discovery-api-indexer#v1.1.0",
         "discovery-store-models": "github:NYPL-discovery/discovery-store-models#v1.4.3",
         "highland": "^2.13.5",
         "pcdm-store-updater": "github:NYPL-discovery/discovery-store-poster#v1.3.0",
@@ -1202,9 +1202,8 @@
       }
     },
     "node_modules/discovery-api-indexer": {
-      "version": "1.0.3",
-      "resolved": "git+ssh://git@github.com/NYPL-discovery/discovery-api-indexer.git#f2abaf376a718d1686a0e2cb5ed31dba6e6c6ba2",
-      "integrity": "sha512-Kg7Ld9TDnW9T2vMTj2IMHIyh3oZIfIstOjBNq/knBRsyDiqW7hwChHy31XSMPywzPJgx8kj0xXcB/T49zYfQoA==",
+      "version": "1.1.0",
+      "resolved": "git+ssh://git@github.com/NYPL-discovery/discovery-api-indexer.git#224239be9601eb4e5ebf1950fa3af37009ae8405",
       "license": "MIT",
       "dependencies": {
         "@nypl/nypl-core-objects": "^2.0.0",
@@ -7260,9 +7259,8 @@
       "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
     },
     "discovery-api-indexer": {
-      "version": "git+ssh://git@github.com/NYPL-discovery/discovery-api-indexer.git#f2abaf376a718d1686a0e2cb5ed31dba6e6c6ba2",
-      "integrity": "sha512-Kg7Ld9TDnW9T2vMTj2IMHIyh3oZIfIstOjBNq/knBRsyDiqW7hwChHy31XSMPywzPJgx8kj0xXcB/T49zYfQoA==",
-      "from": "discovery-api-indexer@git+https://github.com/NYPL-discovery/discovery-api-indexer.git#v1.0.3",
+      "version": "git+ssh://git@github.com/NYPL-discovery/discovery-api-indexer.git#224239be9601eb4e5ebf1950fa3af37009ae8405",
+      "from": "discovery-api-indexer@git+https://github.com/NYPL-discovery/discovery-api-indexer.git#v1.1.0",
       "requires": {
         "@nypl/nypl-core-objects": "^2.0.0",
         "@nypl/nypl-data-api-client": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "@nypl/scsb-rest-client": "^1.0.6",
     "avsc": "^5.7.1",
     "deep-object-diff": "^1.1.0",
-    "discovery-api-indexer": "git+https://github.com/NYPL-discovery/discovery-api-indexer.git#v1.0.3",
+    "discovery-api-indexer": "github:NYPL-discovery/discovery-api-indexer#v1.1.0",
     "discovery-store-models": "github:NYPL-discovery/discovery-store-models#v1.4.3",
     "highland": "^2.13.5",
     "pcdm-store-updater": "github:NYPL-discovery/discovery-store-poster#v1.3.0",


### PR DESCRIPTION
Update discovery-api-indexer to v1.1.0 to incorporate [improvements to ISBN indexing](https://github.com/NYPL/discovery-api-indexer/pull/97)