### PR TITLE
Upgrade discovery api indexer to v1.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "@nypl/scsb-rest-client": "^1.0.6",
     "avsc": "^5.7.1",
     "deep-object-diff": "^1.1.0",
-    "discovery-api-indexer": "github:NYPL-discovery/discovery-api-indexer#v1.1.0",
+    "discovery-api-indexer": "github:NYPL-discovery/discovery-api-indexer#v1.2.0",
     "discovery-store-models": "github:NYPL-discovery/discovery-store-models#v1.4.3",
     "highland": "^2.13.5",
     "pcdm-store-updater": "github:NYPL-discovery/discovery-store-poster#v1.3.0",


### PR DESCRIPTION
- Upgrade discovery-api-indexer version to pull in changes related to improved `title_sort`