### PR TITLE
Add [wip] m2 customer code indexing rules

### DIFF
--- a/lib/attach-m2-customer-codes-to-items.js
+++ b/lib/attach-m2-customer-codes-to-items.js
@@ -1,0 +1,38 @@
+const platformApi = require('./platform-api')
+
+/**
+ * Given a location code, returns true if the location is in M2
+ *
+ * Should match:
+ *   mal92, mal98, mal99, mag92, maf92, maf98, maf99, mas92, map92, map98
+ *
+ * Ideally this would be data-driven rather than hard coded, but at writing,
+ * NYPL-Core does not associate M2 customer codes with Sierra holding locations
+ * (only delivery locations)
+*/
+const isM2Location = (location) => /^(mal9|mag9|maf9|mas9|map9)/.test(location)
+
+const attachM2CustomerCodes = async (bib) => {
+  // Get barcodes from M2 items:
+  const barcodes = bib.items
+    .filter((item) => item.barcode)
+    .filter((item) => item.location && isM2Location(item.location.code))
+    .map((item) => item.barcode)
+
+  // Get map relating barcodes to M2 customer codes:
+  const barcodeToM2CustomerCode = await platformApi.m2CustomerCodesForBarcodes(barcodes)
+
+  // Attach .m2CustomerCode to items:
+  bib.items = bib.items.map((item) => {
+    if (barcodeToM2CustomerCode[item.barcode]) {
+      item.m2CustomerCode = barcodeToM2CustomerCode[item.barcode]
+    }
+    return item
+  })
+
+  return bib
+}
+
+module.exports = {
+  attachM2CustomerCodes
+}

--- a/lib/discovery-store-model.js
+++ b/lib/discovery-store-model.js
@@ -16,6 +16,7 @@ const discoveryApiIndexer = require('./discovery-api-indexer')
 const platformApi = require('./platform-api')
 const logger = require('./logger')
 const { attachRecapCustomerCodes } = require('./attach-recap-to-items')
+const { attachM2CustomerCodes } = require('./attach-m2-customer-codes-to-items')
 const { uriForRecordIdentifier } = require('./utils')
 const { parseDatesAndCache } = require('pcdm-store-updater/lib/date-parse')
 
@@ -278,6 +279,18 @@ const filterOutAndDeleteNonResearchBibs = async (bibs) => {
 }
 
 /**
+ * Given a bib, returns same bib with all items having been given a
+ * .m2CustomerCode or .recapCustomerCode if the item has one.
+ */
+const attachCustomerCodes = async (bib) => {
+  await Promise.all([
+    attachRecapCustomerCodes(bib),
+    attachM2CustomerCodes(bib)
+  ])
+  return bib
+}
+
+/**
  *  Given an array of bibs (marcinjson JSON objects), returns a Promise that
  *  resolves an array of DiscoveryStoreBib instances, each wrapping all of the
  *  statements extracted from the original bib. Includes _items and _holdings
@@ -291,9 +304,9 @@ const buildDiscoveryStoreBibs = async (bibs) => {
   platformApi.prefetchHoldingsForBibs(bibs)
 
   const bibsPlusItemsAndRecapCodes = await Promise.all(
-    bibs.map((bib) => {
-      return attachItemsAndHoldingsToBib(bib)
-        .then(attachRecapCustomerCodes)
+    bibs.map(async (bib) => {
+      await attachItemsAndHoldingsToBib(bib)
+      return attachCustomerCodes(bib)
     })
   )
 

--- a/lib/platform-api.js
+++ b/lib/platform-api.js
@@ -197,6 +197,38 @@ const getSchema = (schemaName) => {
   })
 }
 
+/**
+ *
+ *  Given an array of barcodes, resolves a map relating barcoes to M2 customer
+ *  codes (if found).
+ */
+const m2CustomerCodesForBarcodes = async (barcodes, offset = 0, map = {}) => {
+  if (!barcodes || barcodes.length === 0) return {}
+
+  // Batch calls to the m2-customer-code-store in groups of 200 barcodes:
+  const batchSize = 200
+  const barcodesBatch = barcodes.slice(offset, offset + batchSize)
+
+  const client = await init()
+  const response = await client.get(`m2-customer-codes?barcodes=${barcodesBatch.join(',')}`)
+
+  // Convert response to a map relating barcode to CC:
+  const responseAsMap = response.data
+    .reduce((h, result) => {
+      return Object.assign(h, { [result.barcode]: result.m2CustomerCode })
+    }, {})
+  // Merge this map with the map built from previous batched calls:
+  map = Object.assign(map, responseAsMap)
+
+  // If there are no more batches to fetch, return map
+  if (barcodes.length <= offset + batchSize) {
+    return map
+  } else {
+    // There are more batches to fetch; recurse:
+    return m2CustomerCodesForBarcodes(barcodes, offset + batchSize, map)
+  }
+}
+
 module.exports = {
   bibsForItems,
   bibsForHoldings,
@@ -205,6 +237,7 @@ module.exports = {
   getSchema,
   bibById,
   prefetchHoldingsForBibs,
+  m2CustomerCodesForBarcodes,
   internal: {
     init,
     bibIdentifiersForItems


### PR DESCRIPTION
So far this is just the basic code for attaching `.m2CustomerCode`s to items by looking up the items' barcodes in the M2CustomerCodeStore