### PR TITLE
Improve identify-ids-by-query script

### DIFF
--- a/scripts/identify-ids-by-query.js
+++ b/scripts/identify-ids-by-query.js
@@ -86,9 +86,6 @@ function parseResultAndScroll (result, records = []) {
   }
 
   if (records.length < result.hits.total) {
-    const page = Math.ceil(records.length / argv.size)
-    const pages = Math.ceil(result.hits.total / argv.size)
-
     // Periodically report on progress and save records:
     if (records.length % 1000 === 0) {
       // Report on progress:
@@ -149,7 +146,7 @@ if (argv.query || argv.queryfile) {
     if (argv.queryfile) {
       try {
         fs.statSync(argv.queryfile)
-      } catch(e) {
+      } catch (e) {
         die(`Could not find ${argv.queryfile}`)
       }
     }


### PR DESCRIPTION
Adds light improvements to the ./scripts/identify-ids-by-query script:
 - The --queryfile param may specify any filesystem path - no expectation that query-files are in ./scripts/
 - Better reporting on progress
 - Dynamic ETA