### PR TITLE
Hotfix production holding with nonexistent bib

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,9 +29,9 @@ const removeBibsWithInvalidNyplSources = async (bibs) => {
  * rebuild and save the ES document for each
  */
 const fullRebuildForBibs = async (bibs) => {
-  logger.debug(`Full rebuild for bibs: ${bibs.map((b) => `${b.nyplSource}/${b.id}`).join(', ')}`)
-
   bibs = await removeBibsWithInvalidNyplSources(bibs)
+
+  logger.debug(`Full rebuild for bibs: ${bibs.map((b) => `${b.nyplSource}/${b.id}`).join(', ')}`)
 
   return discoveryStoreModel.buildDiscoveryStoreBibs(bibs)
     .then(discoveryApiIndexer.reindexBibs)

--- a/lib/platform-api.js
+++ b/lib/platform-api.js
@@ -213,10 +213,11 @@ const m2CustomerCodesForBarcodes = async (barcodes, offset = 0, map = {}) => {
   const response = await client.get(`m2-customer-codes?barcodes=${barcodesBatch.join(',')}`)
 
   // Convert response to a map relating barcode to CC:
-  const responseAsMap = response.data
-    .reduce((h, result) => {
+  const responseAsMap = (response && response.data && Array.isArray(response.data)) ?
+    response.data.reduce((h, result) => {
       return Object.assign(h, { [result.barcode]: result.m2CustomerCode })
-    }, {})
+    }, {}) :
+    {}
   // Merge this map with the map built from previous batched calls:
   map = Object.assign(map, responseAsMap)
 

--- a/lib/platform-api.js
+++ b/lib/platform-api.js
@@ -213,11 +213,11 @@ const m2CustomerCodesForBarcodes = async (barcodes, offset = 0, map = {}) => {
   const response = await client.get(`m2-customer-codes?barcodes=${barcodesBatch.join(',')}`)
 
   // Convert response to a map relating barcode to CC:
-  const responseAsMap = (response && response.data && Array.isArray(response.data)) ?
-    response.data.reduce((h, result) => {
-      return Object.assign(h, { [result.barcode]: result.m2CustomerCode })
-    }, {}) :
-    {}
+  const responseAsMap = (response && response.data && Array.isArray(response.data))
+    ? response.data.reduce((h, result) => {
+        return Object.assign(h, { [result.barcode]: result.m2CustomerCode })
+      }, {})
+    : {}
   // Merge this map with the map built from previous batched calls:
   map = Object.assign(map, responseAsMap)
 

--- a/lib/platform-api.js
+++ b/lib/platform-api.js
@@ -84,11 +84,13 @@ const bibIdentifiersForHoldings = (holdings) => {
 }
 
 // TODO: optimize by fetching all bibs at once via ?nyplSource=_&id=123,456,789
-const bibsForHoldings = (holdings) => {
-  return Promise.all(
+const bibsForHoldings = async (holdings) => {
+  const bibs = await Promise.all(
     bibIdentifiersForHoldings(holdings)
       .map((ids) => bibById(ids.nyplSource, ids.id))
   )
+  // Filter out holdings records that refer to non-existent bibs:
+  return bibs.filter((bib) => !!bib)
 }
 
 let HOLDINGS_CACHE = {}


### PR DESCRIPTION
Two hotfixes for handling bad data found in production:
 - Quietly fail to index anything when a Holding record comes through that has an invalid bibid (e.g. non-existent). Previously, it hit a runtime error.
 - Handle case where m2-customer-code store returns no matches. Previously it failed hard due to expectation of a `data` element in the response.